### PR TITLE
Add FoVAlignment

### DIFF
--- a/acceptance_modelisation/grid3d_acceptance_map_creator.py
+++ b/acceptance_modelisation/grid3d_acceptance_map_creator.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import astropy.units as u
 import numpy as np
 from gammapy.data import Observations
-from gammapy.irf import Background3D
+from gammapy.irf import Background3D, FoVAlignment
 from gammapy.maps import MapAxis
 from regions import SkyRegion
 
@@ -103,6 +103,6 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
                                                                              np.newaxis] / livetime
 
         acceptance_map = Background3D(axes=[self.energy_axis, extended_offset_axis_x, extended_offset_axis_y],
-                                      data=data_background.to(u.Unit('s-1 MeV-1 sr-1')))
+                                      data=data_background.to(u.Unit('s-1 MeV-1 sr-1')), fov_alignment=FoVAlignment.ALTAZ)
 
         return acceptance_map


### PR DESCRIPTION
closes #5 

As far as I can see, the Background3D model is created in the `AltAz` frame but the the `FoVAlignment` is not set when saving it, this assumes `RaDec` as the FoV frame

```python
from gammapy.irf import Background3D, FoVAlignment
from gammapy.maps import MapAxis

x_axis = MapAxis.from_bounds(-3 * u.deg, 3 * u.deg, 10, name="fov_lon")
y_axis = MapAxis.from_bounds(-3 * u.deg, 3 * u.deg, 10, name="fov_lat")

e_axis = MapAxis.from_energy_bounds(50 * u.GeV, 50 * u.TeV, nbin=10, name='energy')

bkg = Background3D(axes=[e_axis, x_axis, y_axis])
bkg.write('/Users/stefan/Downloads/test.fits.gz')

Background3D.read('/Users/stefan/Downloads/test.fits.gz').fov_alignment

Out[32]: <FoVAlignment.RADEC: 'RADEC'>

bkg = Background3D(axes=[e_axis, x_axis, y_axis], fov_alignment=FoVAlignment.ALTAZ)

bkg.write('/Users/stefan/Downloads/test.fits.gz', overwrite=True)
Background3D.read('/Users/stefan/Downloads/test.fits.gz').fov_alignment

Out[35]: <FoVAlignment.ALTAZ: 'ALTAZ'>
```