### PR TITLE
3D acceleration

### DIFF
--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -313,7 +313,8 @@ class BaseAcceptanceMapCreator(ABC):
                 exclusion_mask = np.zeros(count_map_obs.counts.data.shape[1:])
                 for i in range(len(time_interval) - 1):
                     # Compute the exclusion region in camera frame for the average time
-                    time = (time_interval[i] + time_interval[i+1])/2
+                    dtime = time_interval[i + 1] - time_interval[i]
+                    time = time_interval[i] + dtime/2
                     average_alt_az_frame = AltAz(obstime=time,
                                                  location=obs.observatory_earth_location)
                     average_alt_az_pointing = obs.get_pointing_icrs(time).transform_to(average_alt_az_frame)
@@ -323,7 +324,7 @@ class BaseAcceptanceMapCreator(ABC):
 
                     exclusion_mask_t = ~geom_image.region_mask(exclusion_region_camera_frame) if len(
                         exclusion_region_camera_frame) > 0 else ~Map.from_geom(geom_image)
-                    exclusion_mask += exclusion_mask_t * (time_interval[i + 1] - time_interval[i]).value
+                    exclusion_mask += exclusion_mask_t * (dtime).value
                 exclusion_mask *= 1 / (time_interval[-1] - time_interval[0]).value
 
                 for j in range(count_map_obs.counts.data.shape[0]):

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -13,7 +13,7 @@ from gammapy.datasets import MapDataset
 from gammapy.irf import Background2D, Background3D
 from gammapy.irf.background import BackgroundIRF
 from gammapy.makers import MapDatasetMaker, SafeMaskMaker, FoVBackgroundMaker
-from gammapy.maps import WcsNDMap, WcsGeom, Map, MapAxis
+from gammapy.maps import WcsNDMap, WcsGeom, Map, MapAxis, RegionGeom
 from regions import CircleSkyRegion, SkyRegion
 from scipy.integrate import cumulative_trapezoid
 from scipy.interpolate import interp1d
@@ -80,7 +80,8 @@ class BaseAcceptanceMapCreator(ABC):
         self.max_fraction_pixel_rotation_fov = max_fraction_pixel_rotation_fov
         self.time_resolution_rotation_fov = time_resolution_rotation_fov
 
-    def _transform_obs_to_camera_frame(self, obs: Observation) -> Tuple[Observation, List[SkyRegion]]:
+    @staticmethod
+    def _transform_obs_to_camera_frame(obs: Observation) -> Observation:
         """
         Transform events, pointing and exclusion regions of an obs from a sky frame to camera frame
 
@@ -101,7 +102,7 @@ class BaseAcceptanceMapCreator(ABC):
         altaz_frame = AltAz(obstime=obs.events.time,
                             location=obs.observatory_earth_location)
         events_altaz = obs.events.radec.transform_to(altaz_frame)
-        pointing_altaz = obs.get_pointing_icrs(obs.tmid).transform_to(altaz_frame)
+        pointing_altaz = obs.get_pointing_icrs(obs.events.time).transform_to(altaz_frame)
 
         # Rotation to transform to camera frame
         camera_frame = SkyOffsetFrame(origin=AltAz(alt=pointing_altaz.alt,
@@ -125,13 +126,7 @@ class BaseAcceptanceMapCreator(ABC):
                                        aeff=obs.aeff)
         obs_camera_frame._location = obs.observatory_earth_location
 
-        # Compute the exclusion region in camera frame for the average time
-        average_alt_az_frame = AltAz(obstime=obs_camera_frame.tmid,
-                                     location=obs_camera_frame.observatory_earth_location)
-        average_alt_az_pointing = obs.get_pointing_icrs(obs.tmid).transform_to(average_alt_az_frame)
-        exclusion_region_camera_frame = self._transform_exclusion_region_to_camera_frame(average_alt_az_pointing)
-
-        return obs_camera_frame, exclusion_region_camera_frame
+        return obs_camera_frame
 
     def _transform_exclusion_region_to_camera_frame(self, pointing_altaz: AltAz) -> List[SkyRegion]:
         """
@@ -244,31 +239,6 @@ class BaseAcceptanceMapCreator(ABC):
 
         return map_obs, exclusion_mask
 
-    def _create_camera_map(self,
-                           obs: Observation
-                           ) -> Tuple[MapDataset, WcsNDMap]:
-        """
-        Create the sky map in camera coordinates used for computation.
-
-        Parameters
-        ----------
-        obs : gammapy.data.observations.Observation
-            The observation used to make the sky map.
-
-        Returns
-        -------
-        map_dataset : gammapy.datasets.MapDataset
-            The map dataset in camera coordinates.
-        exclusion_mask : gammapy.maps.WcsNDMap
-            The exclusion mask in camera coordinates.
-        """
-
-        obs_camera_frame, exclusion_region_camera_frame = self._transform_obs_to_camera_frame(obs)
-        map_obs, exclusion_mask = self._create_map(obs_camera_frame, self.geom,
-                                                   exclusion_region_camera_frame, add_bkg=False)
-
-        return map_obs, exclusion_mask
-
     def _compute_time_intervals_based_on_fov_rotation(self, obs: Observation) -> Time:
         """
         Calculate time intervals based on the rotation of the Field of View (FoV).
@@ -300,7 +270,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         return time_interval
 
-    def _create_base_computation_map(self, observations: Observation) -> Tuple[WcsNDMap, WcsNDMap, WcsNDMap, u.Unit]:
+    def _create_base_computation_map(self, observations: Observations) -> Tuple[WcsNDMap, WcsNDMap, WcsNDMap, u.Unit]:
         """
         From a list of observations return a stacked finely binned counts and exposure map in camera frame to compute a model
 
@@ -327,24 +297,42 @@ class BaseAcceptanceMapCreator(ABC):
 
         with erfa_astrom.set(ErfaAstromInterpolator(1000 * u.s)):
             for obs in observations:
+                # Filter events in exclusion regions
+                geom = RegionGeom.from_regions(self.exclude_regions)
+                mask = geom.contains(obs.events.radec)
+                obs._events = obs.events.select_row_subset(~mask)
+
                 time_interval = self._compute_time_intervals_based_on_fov_rotation(obs)
+                camera_frame_obs = self._transform_obs_to_camera_frame(obs)
+                count_map_obs, _ = self._create_map(camera_frame_obs, self.geom, [], add_bkg=False)
+
+                exp_map_obs = MapDataset.create(geom=count_map_obs.geoms['geom'])
+                exp_map_obs_total = MapDataset.create(geom=count_map_obs.geoms['geom'])
+                exp_map_obs.counts.data = camera_frame_obs.observation_live_time_duration.value
+                exp_map_obs_total.counts.data = camera_frame_obs.observation_live_time_duration.value
+                exclusion_mask = np.zeros(count_map_obs.counts.data.shape[1:])
                 for i in range(len(time_interval) - 1):
-                    cut_obs = obs.select_time(Time([time_interval[i], time_interval[i + 1]]))
-                    count_map_obs, exclusion_mask = self._create_camera_map(cut_obs)
+                    # Compute the exclusion region in camera frame for the average time
+                    time = (time_interval[i] + time_interval[i+1])/2
+                    average_alt_az_frame = AltAz(obstime=time,
+                                                 location=obs.observatory_earth_location)
+                    average_alt_az_pointing = obs.get_pointing_icrs(time).transform_to(average_alt_az_frame)
+                    exclusion_region_camera_frame = self._transform_exclusion_region_to_camera_frame(
+                        average_alt_az_pointing)
+                    geom_image = self.geom.to_image()
 
-                    exp_map_obs = MapDataset.create(geom=count_map_obs.geoms['geom'])
-                    exp_map_obs_total = MapDataset.create(geom=count_map_obs.geoms['geom'])
-                    exp_map_obs.counts.data = cut_obs.observation_live_time_duration.value
-                    exp_map_obs_total.counts.data = cut_obs.observation_live_time_duration.value
+                    exclusion_mask_t = ~geom_image.region_mask(exclusion_region_camera_frame) if len(
+                        exclusion_region_camera_frame) > 0 else ~Map.from_geom(geom_image)
+                    exclusion_mask += exclusion_mask_t * (time_interval[i + 1] - time_interval[i]).value
+                exclusion_mask *= 1 / (time_interval[-1] - time_interval[0]).value
 
-                    for j in range(count_map_obs.counts.data.shape[0]):
-                        count_map_obs.counts.data[j, :, :] = count_map_obs.counts.data[j, :, :] * exclusion_mask
-                        exp_map_obs.counts.data[j, :, :] = exp_map_obs.counts.data[j, :, :] * exclusion_mask
+                for j in range(count_map_obs.counts.data.shape[0]):
+                    exp_map_obs.counts.data[j, :, :] = exp_map_obs.counts.data[j, :, :] * exclusion_mask
 
-                    count_map_background.data += count_map_obs.counts.data
-                    exp_map_background.data += exp_map_obs.counts.data
-                    exp_map_background_total.data += exp_map_obs_total.counts.data
-                    livetime += cut_obs.observation_live_time_duration
+                count_map_background.data += count_map_obs.counts.data
+                exp_map_background.data += exp_map_obs.counts.data
+                exp_map_background_total.data += exp_map_obs_total.counts.data
+                livetime += camera_frame_obs.observation_live_time_duration
 
         return count_map_background, exp_map_background, exp_map_background_total, livetime
 


### PR DESCRIPTION
This changes how the exclusion region mask are applied to events and propagated into the exposure maps.

The goal is to make the code faster by transforming event from RaDec to AltAz only once and removing the use of `obs.select_time` to create sub `Observation` associated with the frame rotation. 

To do so, the exclusion mask (defined in RaDec) is apply to events directly in RaDec. Then, for each short time interval, only the exclusion mask transformation is done using the middle time of the current interval. The "average" exclusion mask (in camera frame) is then used to correct the exposure map.

Results : 

For two sets of data, 
crab 4 runs at low zenith : 82seconds -> 23 seconds
Boomerang 19 runs at high zenith : 60 seconds -> 10 seconds
So this code is roughly 5 times faster using this limited test set.

Side effect : solve errors occurring when a time interval had no events but the code would try to do the frame conversion. Closes #8 #7 

In the following plots obtained with the Boomerang dataset, we can also see that IRFs are the same and that counts map and exposure maps are also the same. Counts map actually differ slightly on exclusion region edges but this is probably a geometric and binning effect.

IRF main branch : 
![bkgacceptance3Dpeek_mainbranch](https://github.com/mdebony/acceptance_modelisation/assets/35919817/e340f735-afa8-4596-b678-a474149d9b7d)
IRF this branch : 
![bkgacceptance3Dpeek_thisbranch](https://github.com/mdebony/acceptance_modelisation/assets/35919817/2ae27d48-378a-463b-b06f-0ababa186fb6)

Count / exposure / full exposure main branch:
![counts_expmap_firstEbin_mainbranch](https://github.com/mdebony/acceptance_modelisation/assets/35919817/f2ecdae2-4649-4217-ac65-04ef30bab70a)
Count / exposure / full exposure this branch:
![counts_expmap_firstEbin_thisbranch](https://github.com/mdebony/acceptance_modelisation/assets/35919817/67ce5d9d-7800-468f-8c19-e98a579585d0)

