### PR TITLE
Generalise logging usage

### DIFF
--- a/acceptance_modelisation/base_radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_radial_acceptance_map_creator.py
@@ -22,8 +22,7 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
                  initial_cos_zenith_binning: float = 0.01,
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_rotation_fov: u.Quantity = 0.1 * u.s,
-                 verbose: bool = False) -> None:
+                 time_resolution_rotation_fov: u.Quantity = 0.1 * u.s) -> None:
         """
         Create the class for calculating radial acceptance model
 
@@ -49,8 +48,6 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
         time_resolution_rotation_fov : astropy.unit.Quantity, optional
             Time resolution to use for the computation of the rotation of the FoV
-        verbose : bool, optional
-            If True, print informations related to cos zenith binning
         """
 
         # If no exclusion region, default it as an empty list
@@ -68,7 +65,7 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
         super().__init__(energy_axis, max_offset, spatial_resolution, exclude_regions,
                          cos_zenith_binning_method, cos_zenith_binning_parameter_value,
                          initial_cos_zenith_binning, max_angular_separation_wobble, max_fraction_pixel_rotation_fov,
-                         time_resolution_rotation_fov,verbose)
+                         time_resolution_rotation_fov)
 
     def create_acceptance_map(self, observations: Observations) -> Background2D:
         """

--- a/acceptance_modelisation/grid3d_acceptance_map_creator.py
+++ b/acceptance_modelisation/grid3d_acceptance_map_creator.py
@@ -31,8 +31,7 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
                  method='stack',
                  fit_fnc='gaussian2d',
                  fit_seeds=None,
-                 fit_bounds=None,
-                 verbose: bool = False) -> None:
+                 fit_bounds=None) -> None:
         """
         Create the class for calculating 3D grid acceptance model
 
@@ -67,8 +66,6 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
             Seeds of the parameters of the function to fit. Normalisation parameter is ignored if given.
         fit_bounds: dict, can optionally be None if using a built-in function
             Bounds of the parameters of the function to fit. Normalisation parameter is ignored if given.
-        verbose : bool, optional
-            If True, print informations related to cos zenith binning
         """
 
         # If no exclusion region, default it as an empty list
@@ -95,7 +92,7 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
         super().__init__(energy_axis, max_offset, spatial_resolution, exclude_regions,
                          cos_zenith_binning_method, cos_zenith_binning_parameter_value,
                          initial_cos_zenith_binning, max_angular_separation_wobble, max_fraction_pixel_rotation_fov,
-                         time_resolution_rotation_fov, verbose)
+                         time_resolution_rotation_fov)
 
     def fit_background(self, count_map, exp_map_total, exp_map):
         centers = self.offset_axis.center.to_value(u.deg)

--- a/acceptance_modelisation/radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/radial_acceptance_map_creator.py
@@ -21,8 +21,7 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
                  initial_cos_zenith_binning: float = 0.01,
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_rotation_fov: u.Quantity = 0.1 * u.s,
-                 verbose: bool = False) -> None:
+                 time_resolution_rotation_fov: u.Quantity = 0.1 * u.s) -> None:
         """
         Create the class for calculating radial acceptance model
         This class should be use when strict 2D model is good enough
@@ -49,8 +48,6 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
         time_resolution_rotation_fov : astropy.unit.Quantity, optional
             Time resolution to use for the computation of the rotation of the FoV
-        verbose : bool, optional
-            If True, print informations related to cos zenith binning
         """
 
         # Initiate upper instance
@@ -63,8 +60,7 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
                          initial_cos_zenith_binning=initial_cos_zenith_binning,
                          max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
                          max_angular_separation_wobble=max_angular_separation_wobble,
-                         time_resolution_rotation_fov=time_resolution_rotation_fov,
-                         verbose=verbose)
+                         time_resolution_rotation_fov=time_resolution_rotation_fov)
 
     def _create_base_computation_map(self, observations: Observation) -> Tuple[WcsNDMap, WcsNDMap, WcsNDMap, u.Unit]:
         """
@@ -111,4 +107,3 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
             livetime += obs.observation_live_time_duration
 
         return count_map_background, exp_map_background, exp_map_background_total, livetime
-

--- a/acceptance_modelisation/toolbox.py
+++ b/acceptance_modelisation/toolbox.py
@@ -7,6 +7,8 @@ from copy import deepcopy
 import logging
 import numpy as np
 
+logger = logging.getLogger(__name__)
+
 def compute_rotation_speed_fov(time_evaluation: Time,
                                pointing_sky: SkyCoord,
                                observatory_earth_location: EarthLocation) -> u.Quantity:
@@ -76,7 +78,7 @@ def get_unique_wobble_pointings(observations: Observations, max_angular_separati
         ra_observations = all_ra_observations[mask_all_remaining]
         dec_observations = all_dec_observations[mask_all_remaining]
 
-    logging.info(f"{len(wobbles_dict)} wobbles were found:")
+    logger.info(f"{len(wobbles_dict)} wobbles were found:")
     for key, value in wobbles_dict.items():
-        logging.info(f"{key}: [{value[0].round(2)}, {value[1].round(2)}]")
+        logger.info(f"{key}: [{value[0].round(2)}, {value[1].round(2)}]")
     return wobbles


### PR DESCRIPTION
Add a logger (could be shortened to log) for every module using the logging package and use it for every log message. 

Remove every usage of print and associated "verbose" parameter in classes.

First item of issue #16 