### PR TITLE
Add option for splitting runs in zenith bin computation

### DIFF
--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -37,7 +37,7 @@ class BaseAcceptanceMapCreator(ABC):
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
                  zenith_binning_run_splitting: bool = False,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_run_splitting: u.Quantity = 0.1 * u.s, ) -> None:
+                 time_resolution: u.Quantity = 0.1 * u.s) -> None:
         """
         Create the class for calculating radial acceptance model.
 
@@ -64,7 +64,7 @@ class BaseAcceptanceMapCreator(ABC):
             Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-        time_resolution_run_splitting : astropy.units.Quantity, optional
+        time_resolution : astropy.units.Quantity, optional
             Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         """
 
@@ -93,7 +93,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         # Store computation parameters for run splitting
         self.max_fraction_pixel_rotation_fov = max_fraction_pixel_rotation_fov
-        self.time_resolution_run_splitting = time_resolution_run_splitting
+        self.time_resolution = time_resolution
         self.zenith_binning_run_splitting = zenith_binning_run_splitting
 
     @staticmethod
@@ -270,7 +270,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         # Determine time interval for cutting the obs as function of the rotation of the Fov
         n_bin = max(2, int(np.rint(
-            ((obs.tstop - obs.tstart) / self.time_resolution_run_splitting).to_value(u.dimensionless_unscaled))))
+            ((obs.tstop - obs.tstart) / self.time_resolution).to_value(u.dimensionless_unscaled))))
         time_axis = np.linspace(obs.tstart, obs.tstop, num=n_bin)
         rotation_speed_fov = compute_rotation_speed_fov(time_axis, obs.get_pointing_icrs(obs.tmid),
                                                         obs.observatory_earth_location)
@@ -449,7 +449,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         # Create the time axis
         n_bin = max(2, int(np.rint(
-            ((obs.tstop - obs.tstart) / self.time_resolution_run_splitting).to_value(u.dimensionless_unscaled))))
+            ((obs.tstop - obs.tstart) / self.time_resolution).to_value(u.dimensionless_unscaled))))
         time_axis = np.linspace(obs.tstart, obs.tstop, num=n_bin)
 
         # Compute the zenith for each evaluation time

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -494,7 +494,7 @@ class BaseAcceptanceMapCreator(ABC):
             raise
         per_wobble = i_method < 0
 
-        # Initial binning edge
+        # Initial bins edges
         cos_zenith_bin = np.sort(np.arange(1.0, 0. - self.initial_cos_zenith_binning, -self.initial_cos_zenith_binning))
         zenith_bin = np.rad2deg(np.arccos(cos_zenith_bin)) * u.deg
 
@@ -510,7 +510,7 @@ class BaseAcceptanceMapCreator(ABC):
         else:
             compute_observations = observations
 
-        # Determine initial binning value
+        # Determine initial bins values
         cos_zenith_observations = np.array([np.cos(obs.get_pointing_altaz(obs.tmid).zen) for obs in compute_observations])
         livetime_observations = np.array([obs.observation_live_time_duration.to_value(u.s) for obs in compute_observations])
 

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -326,7 +326,7 @@ class BaseAcceptanceMapCreator(ABC):
                 # Evaluate the average exclusion mask in camera frame
                 # by evaluating it on time intervals short compared to the field of view rotation
                 exclusion_mask = np.zeros(count_map_obs.counts.data.shape[1:])
-                time_interval = self._compute_time_intervals_based_on_zenith_bin(obs)
+                time_interval = self._compute_time_intervals_based_on_fov_rotation(obs)
                 for i in range(len(time_interval) - 1):
                     # Compute the exclusion region in camera frame for the average time
                     dtime = time_interval[i + 1] - time_interval[i]

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -501,7 +501,7 @@ class BaseAcceptanceMapCreator(ABC):
         # Cut observations if requested
         if self.zenith_binning_run_splitting:
             if abs(i_method) == 2:
-                logger.warning('Using a zenith binning requirement n_observation at the same time of using run splitting is not recommended and could lead to poor model. We recommend switching to a binning requirement based on livetime.')
+                logger.warning('Using a zenith binning requirement based on n_observation while using run splitting is not recommended and could lead to poor models. We recommend switching to a binning requirement based on livetime.')
             compute_observations = Observations()
             for obs in observations:
                 time_interval = self._compute_time_intervals_based_on_zenith_bin(obs, zenith_bin)

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -59,7 +59,7 @@ class BaseAcceptanceMapCreator(ABC):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
-        zenith_binning_run_splitting : float, optional
+        zenith_binning_run_splitting : bool, optional
             If true, will split each run to match zenith binning for the base model computation
             Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -501,7 +501,7 @@ class BaseAcceptanceMapCreator(ABC):
         # Cut observations if requested
         if self.zenith_binning_run_splitting:
             if abs(i_method) == 2:
-                logger.warning('Using zenith bin and run splitting at the same time is not recommanded and could lead to poor model. We recommand switching to a binning requirement based on livetime.')
+                logger.warning('Using a zenith binning requirement n_observation at the same time of using run splitting is not recommanded and could lead to poor model. We recommand switching to a binning requirement based on livetime.')
             compute_observations = Observations()
             for obs in observations:
                 time_interval = self._compute_time_intervals_based_on_zenith_bin(obs, zenith_bin)

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -35,8 +35,9 @@ class BaseAcceptanceMapCreator(ABC):
                  cos_zenith_binning_parameter_value: int = 3600,
                  initial_cos_zenith_binning: float = 0.01,
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
+                 zenith_binning_run_splitting: bool = False,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_rotation_fov: u.Quantity = 0.1 * u.s) -> None:
+                 time_resolution_run_splitting: u.Quantity = 0.1 * u.s, ) -> None:
         """
         Create the class for calculating radial acceptance model.
 
@@ -58,10 +59,12 @@ class BaseAcceptanceMapCreator(ABC):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
+        zenith_binning_run_splitting : flaot, optional
+            If true, will split each run to match zenith binning for the base model computation, no effect on the interpolation phase itself, could be compute expensive
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-        time_resolution_rotation_fov : astropy.units.Quantity, optional
-            Time resolution to use for the computation of the rotation of the FoV
+        time_resolution_run_splitting : astropy.units.Quantity, optional
+            Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         """
 
         # If no exclusion region, default it as an empty list
@@ -87,9 +90,10 @@ class BaseAcceptanceMapCreator(ABC):
             'Computation will be made with a bin size of {:.3f} arcmin'.format(
                 self.spatial_bin_size.to_value(u.arcmin)))
 
-        # Store rotation computation parameters
+        # Store computation parameters for run splitting
         self.max_fraction_pixel_rotation_fov = max_fraction_pixel_rotation_fov
-        self.time_resolution_rotation_fov = time_resolution_rotation_fov
+        self.time_resolution_run_splitting = time_resolution_run_splitting
+        self.zenith_binning_run_splitting = zenith_binning_run_splitting
 
     @staticmethod
     def _transform_obs_to_camera_frame(obs: Observation) -> Observation:
@@ -265,7 +269,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         # Determine time interval for cutting the obs as function of the rotation of the Fov
         n_bin = max(2, int(np.rint(
-            ((obs.tstop - obs.tstart) / self.time_resolution_rotation_fov).to_value(u.dimensionless_unscaled))))
+            ((obs.tstop - obs.tstart) / self.time_resolution_run_splitting).to_value(u.dimensionless_unscaled))))
         time_axis = np.linspace(obs.tstart, obs.tstop, num=n_bin)
         rotation_speed_fov = compute_rotation_speed_fov(time_axis, obs.get_pointing_icrs(obs.tmid),
                                                         obs.observatory_earth_location)
@@ -322,7 +326,7 @@ class BaseAcceptanceMapCreator(ABC):
                 # Evaluate the average exclusion mask in camera frame
                 # by evaluating it on time intervals short compared to the field of view rotation
                 exclusion_mask = np.zeros(count_map_obs.counts.data.shape[1:])
-                time_interval = self._compute_time_intervals_based_on_fov_rotation(obs)
+                time_interval = self._compute_time_intervals_based_on_zenith_bin(obs)
                 for i in range(len(time_interval) - 1):
                     # Compute the exclusion region in camera frame for the average time
                     dtime = time_interval[i + 1] - time_interval[i]
@@ -425,6 +429,41 @@ class BaseAcceptanceMapCreator(ABC):
 
         return normalised_acceptance_map
 
+    def _compute_time_intervals_based_on_zenith_bin(self, obs: Observation, edge_zenith_bin: u.Quantity) -> Time:
+        """
+        Calculate time intervals based on an input zenith binning
+
+        Parameters
+        ----------
+        obs : gammapy.data.observations.Observation
+            The observation used to calculate time intervals.
+        edge_zenith_bin : astropy.units.Quantity
+            The edge of the bins used for zenith binning
+
+        Returns
+        -------
+        time_intervals : astropy.time.Time
+            The time intervals for cutting the observation into time bins.
+        """
+
+        # Create the time axis
+        n_bin = max(2, int(np.rint(
+            ((obs.tstop - obs.tstart) / self.time_resolution_run_splitting).to_value(u.dimensionless_unscaled))))
+        time_axis = np.linspace(obs.tstart, obs.tstop, num=n_bin)
+
+        # Compute the zenith for each evaluation time
+        altaz_coordinates = obs.get_pointing_altaz(time_axis)
+        zenith_values = altaz_coordinates.zen
+        if np.any(zenith_values < np.min(edge_zenith_bin)) or np.any(zenith_values > np.max(edge_zenith_bin)):
+            logger.error('Run with zenith value outside of the considered range for zenith binning')
+
+        # Split the time interval to transition between zenith bin
+        id_bin = np.digitize(zenith_values, edge_zenith_bin)
+        bin_transition = np.argwhere(id_bin[2:] != id_bin[1:-1])
+        time_interval = Time([obs.tstart, ] + [time_axis[1:-1][bin_transition], ] + [obs.tstop, ])
+
+        return time_interval
+
     def _create_model_cos_zenith_binned(self,
                                         observations: Observations
                                         ) -> dict[Any, BackgroundIRF]:
@@ -442,6 +481,7 @@ class BaseAcceptanceMapCreator(ABC):
             A dict with observation number as key and a background model that could be used as an acceptance model associated at each key
 
         """
+
         # Determine binning method. Convention : per_wobble methods have negative values
         methods = {'min_livetime': 1, 'min_livetime_per_wobble': -1, 'min_n_observation': 2,
                    'min_n_observation_per_wobble': -2}
@@ -453,10 +493,23 @@ class BaseAcceptanceMapCreator(ABC):
             raise
         per_wobble = i_method < 0
 
-        # Determine initial binning value
+        # Initial binning edge
         cos_zenith_bin = np.sort(np.arange(1.0, 0. - self.initial_cos_zenith_binning, -self.initial_cos_zenith_binning))
-        cos_zenith_observations = np.array([np.cos(obs.get_pointing_altaz(obs.tmid).zen) for obs in observations])
-        livetime_observations = np.array([obs.observation_live_time_duration.to_value(u.s) for obs in observations])
+        zenith_bin = np.rad2deg(np.arccos(cos_zenith_bin)) * u.deg
+
+        # Cut observations if requested
+        if self.zenith_binning_run_splitting:
+            if abs(i_method) == 2:
+                logger.warning('Using zenith bin and run splitting at the same time is not recommanded and could lead to poor model. We recommand switching to a binning requirement based on livetime.')
+            compute_observations = Observations()
+            for obs in observations:
+                compute_observations.append(self._compute_time_intervals_based_on_zenith_bin(obs, zenith_bin))
+        else:
+            compute_observations = observations
+
+        # Determine initial binning value
+        cos_zenith_observations = np.array([np.cos(obs.get_pointing_altaz(obs.tmid).zen) for obs in compute_observations])
+        livetime_observations = np.array([obs.observation_live_time_duration.to_value(u.s) for obs in compute_observations])
 
         # Select the quantity used to count observations
         if i_method in [-1, 1]:
@@ -467,7 +520,7 @@ class BaseAcceptanceMapCreator(ABC):
         # Gather runs per separation angle or all together. Define the minimum multiplicity (-1) to create a zenith bin.
         if per_wobble:
             wobble_observations = np.array(
-                get_unique_wobble_pointings(observations, self.max_angular_separation_wobble))
+                get_unique_wobble_pointings(compute_observations, self.max_angular_separation_wobble))
             multiplicity_wob = 1
         else:
             wobble_observations = np.full(len(cos_zenith_observations), 'any', dtype=np.object_)
@@ -516,7 +569,7 @@ class BaseAcceptanceMapCreator(ABC):
         binned_observations = []
         for i in range((len(cos_zenith_bin) - 1)):
             binned_observations.append(Observations())
-        for obs in observations:
+        for obs in compute_observations:
             binned_observations[np.digitize(np.cos(obs.get_pointing_altaz(obs.tmid).zen), cos_zenith_bin) - 1].append(
                 obs)
 

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -459,7 +459,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         # Split the time interval to transition between zenith bin
         id_bin = np.digitize(zenith_values, edge_zenith_bin)
-        bin_transition = np.argwhere(id_bin[2:] != id_bin[1:-1])
+        bin_transition = id_bin[2:] != id_bin[1:-1]
         time_interval = Time([obs.tstart, ] + [time_axis[1:-1][bin_transition], ] + [obs.tstop, ])
 
         return time_interval
@@ -503,7 +503,10 @@ class BaseAcceptanceMapCreator(ABC):
                 logger.warning('Using zenith bin and run splitting at the same time is not recommanded and could lead to poor model. We recommand switching to a binning requirement based on livetime.')
             compute_observations = Observations()
             for obs in observations:
-                compute_observations.append(self._compute_time_intervals_based_on_zenith_bin(obs, zenith_bin))
+                time_interval = self._compute_time_intervals_based_on_zenith_bin(obs, zenith_bin)
+                for i in range(len(time_interval) - 1):
+                    compute_observations.append(obs.select_time(Time([time_interval[i], time_interval[i + 1]])))
+                compute_observations_len = len(compute_observations)
         else:
             compute_observations = observations
 

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -59,8 +59,9 @@ class BaseAcceptanceMapCreator(ABC):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
-        zenith_binning_run_splitting : flaot, optional
-            If true, will split each run to match zenith binning for the base model computation, no effect on the interpolation phase itself, could be compute expensive
+        zenith_binning_run_splitting : float, optional
+            If true, will split each run to match zenith binning for the base model computation
+            Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
         time_resolution_run_splitting : astropy.units.Quantity, optional

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -501,7 +501,7 @@ class BaseAcceptanceMapCreator(ABC):
         # Cut observations if requested
         if self.zenith_binning_run_splitting:
             if abs(i_method) == 2:
-                logger.warning('Using a zenith binning requirement n_observation at the same time of using run splitting is not recommanded and could lead to poor model. We recommand switching to a binning requirement based on livetime.')
+                logger.warning('Using a zenith binning requirement n_observation at the same time of using run splitting is not recommended and could lead to poor model. We recommend switching to a binning requirement based on livetime.')
             compute_observations = Observations()
             for obs in observations:
                 time_interval = self._compute_time_intervals_based_on_zenith_bin(obs, zenith_bin)

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -507,7 +507,6 @@ class BaseAcceptanceMapCreator(ABC):
                 time_interval = self._compute_time_intervals_based_on_zenith_bin(obs, zenith_bin)
                 for i in range(len(time_interval) - 1):
                     compute_observations.append(obs.select_time(Time([time_interval[i], time_interval[i + 1]])))
-                compute_observations_len = len(compute_observations)
         else:
             compute_observations = observations
 

--- a/acceptance_modelisation/base_radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_radial_acceptance_map_creator.py
@@ -21,8 +21,9 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
                  cos_zenith_binning_parameter_value: int = 3600,
                  initial_cos_zenith_binning: float = 0.01,
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
+                 zenith_binning_run_splitting: bool = False,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_rotation_fov: u.Quantity = 0.1 * u.s) -> None:
+                 time_resolution_run_splitting: u.Quantity = 0.1 * u.s) -> None:
         """
         Create the class for calculating radial acceptance model
 
@@ -44,10 +45,12 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
+        zenith_binning_run_splitting : flaot, optional
+            If true, will split each run to match zenith binning for the base model computation, no effect on the interpolation phase itself, could be compute expensive
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-        time_resolution_rotation_fov : astropy.unit.Quantity, optional
-            Time resolution to use for the computation of the rotation of the FoV
+        time_resolution_run_splitting : astropy.units.Quantity, optional
+            Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         """
 
         # If no exclusion region, default it as an empty list
@@ -62,10 +65,17 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
         max_offset = np.max(self.offset_axis.edges)
 
         # Initiate upper instance
-        super().__init__(energy_axis, max_offset, spatial_resolution, exclude_regions,
-                         cos_zenith_binning_method, cos_zenith_binning_parameter_value,
-                         initial_cos_zenith_binning, max_angular_separation_wobble, max_fraction_pixel_rotation_fov,
-                         time_resolution_rotation_fov)
+        super().__init__(energy_axis=energy_axis,
+                         max_offset=max_offset,
+                         spatial_resolution=spatial_resolution,
+                         exclude_regions=exclude_regions,
+                         cos_zenith_binning_method=cos_zenith_binning_method,
+                         cos_zenith_binning_parameter_value=cos_zenith_binning_parameter_value,
+                         initial_cos_zenith_binning=initial_cos_zenith_binning,
+                         max_angular_separation_wobble=max_angular_separation_wobble,
+                         max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
+                         zenith_binning_run_splitting=zenith_binning_run_splitting,
+                         time_resolution_run_splitting=time_resolution_run_splitting)
 
     def create_acceptance_map(self, observations: Observations) -> Background2D:
         """

--- a/acceptance_modelisation/base_radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_radial_acceptance_map_creator.py
@@ -23,7 +23,7 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
                  zenith_binning_run_splitting: bool = False,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_run_splitting: u.Quantity = 0.1 * u.s) -> None:
+                 time_resolution: u.Quantity = 0.1 * u.s) -> None:
         """
         Create the class for calculating radial acceptance model
 
@@ -50,7 +50,7 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
             Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-        time_resolution_run_splitting : astropy.units.Quantity, optional
+        time_resolution : astropy.units.Quantity, optional
             Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         """
 
@@ -74,9 +74,9 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
                          cos_zenith_binning_parameter_value=cos_zenith_binning_parameter_value,
                          initial_cos_zenith_binning=initial_cos_zenith_binning,
                          max_angular_separation_wobble=max_angular_separation_wobble,
-                         max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
                          zenith_binning_run_splitting=zenith_binning_run_splitting,
-                         time_resolution_run_splitting=time_resolution_run_splitting)
+                         max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
+                         time_resolution=time_resolution)
 
     def create_acceptance_map(self, observations: Observations) -> Background2D:
         """

--- a/acceptance_modelisation/base_radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_radial_acceptance_map_creator.py
@@ -45,8 +45,9 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
-        zenith_binning_run_splitting : flaot, optional
-            If true, will split each run to match zenith binning for the base model computation, no effect on the interpolation phase itself, could be compute expensive
+        zenith_binning_run_splitting : float, optional
+            If true, will split each run to match zenith binning for the base model computation
+            Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
         time_resolution_run_splitting : astropy.units.Quantity, optional

--- a/acceptance_modelisation/base_radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_radial_acceptance_map_creator.py
@@ -45,7 +45,7 @@ class BaseRadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
-        zenith_binning_run_splitting : float, optional
+        zenith_binning_run_splitting : bool, optional
             If true, will split each run to match zenith binning for the base model computation
             Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional

--- a/acceptance_modelisation/grid3d_acceptance_map_creator.py
+++ b/acceptance_modelisation/grid3d_acceptance_map_creator.py
@@ -26,8 +26,9 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
                  cos_zenith_binning_parameter_value: int = 3600,
                  initial_cos_zenith_binning: float = 0.01,
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
+                 zenith_binning_run_splitting: bool = False,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_rotation_fov: u.Quantity = 0.1 * u.s,
+                 time_resolution_run_splitting: u.Quantity = 0.1 * u.s,
                  method='stack',
                  fit_fnc='gaussian2d',
                  fit_seeds=None,
@@ -53,10 +54,12 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
+        zenith_binning_run_splitting : flaot, optional
+            If true, will split each run to match zenith binning for the base model computation, no effect on the interpolation phase itself, could be compute expensive
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-        time_resolution_rotation_fov : astropy.unit.Quantity, optional
-            Time resolution to use for the computation of the rotation of the FoV
+       time_resolution_run_splitting : astropy.units.Quantity, optional
+            Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         method : str, optional
             Decide if the acceptance is a direct event stacking or a fitted model. 'stack' or 'fit'
         fit_fnc: str or function
@@ -89,10 +92,17 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
         self.fit_bounds = fit_bounds
 
         # Initiate upper instance
-        super().__init__(energy_axis, max_offset, spatial_resolution, exclude_regions,
-                         cos_zenith_binning_method, cos_zenith_binning_parameter_value,
-                         initial_cos_zenith_binning, max_angular_separation_wobble, max_fraction_pixel_rotation_fov,
-                         time_resolution_rotation_fov)
+        super().__init__(energy_axis=energy_axis,
+                         max_offset=max_offset,
+                         spatial_resolution=spatial_resolution,
+                         exclude_regions=exclude_regions,
+                         cos_zenith_binning_method=cos_zenith_binning_method,
+                         cos_zenith_binning_parameter_value=cos_zenith_binning_parameter_value,
+                         initial_cos_zenith_binning=initial_cos_zenith_binning,
+                         max_angular_separation_wobble=max_angular_separation_wobble,
+                         max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
+                         zenith_binning_run_splitting=zenith_binning_run_splitting,
+                         time_resolution_run_splitting=time_resolution_run_splitting)
 
     def fit_background(self, count_map, exp_map_total, exp_map):
         centers = self.offset_axis.center.to_value(u.deg)

--- a/acceptance_modelisation/grid3d_acceptance_map_creator.py
+++ b/acceptance_modelisation/grid3d_acceptance_map_creator.py
@@ -57,9 +57,9 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
         zenith_binning_run_splitting : float, optional
             If true, will split each run to match zenith binning for the base model computation
             Could be computationally expensive, especially at high zenith with a high resolution zenith binning
-        max_fraction_pixel_rotation_fov : float, optional
+        max_fraction_pixel_rotation_fov : bool, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-       time_resolution_run_splitting : astropy.units.Quantity, optional
+        time_resolution_run_splitting : astropy.units.Quantity, optional
             Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         method : str, optional
             Decide if the acceptance is a direct event stacking or a fitted model. 'stack' or 'fit'

--- a/acceptance_modelisation/grid3d_acceptance_map_creator.py
+++ b/acceptance_modelisation/grid3d_acceptance_map_creator.py
@@ -54,8 +54,9 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
-        zenith_binning_run_splitting : flaot, optional
-            If true, will split each run to match zenith binning for the base model computation, no effect on the interpolation phase itself, could be compute expensive
+        zenith_binning_run_splitting : float, optional
+            If true, will split each run to match zenith binning for the base model computation
+            Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
        time_resolution_run_splitting : astropy.units.Quantity, optional

--- a/acceptance_modelisation/grid3d_acceptance_map_creator.py
+++ b/acceptance_modelisation/grid3d_acceptance_map_creator.py
@@ -28,7 +28,7 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
                  zenith_binning_run_splitting: bool = False,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_run_splitting: u.Quantity = 0.1 * u.s,
+                 time_resolution: u.Quantity = 0.1 * u.s,
                  method='stack',
                  fit_fnc='gaussian2d',
                  fit_seeds=None,
@@ -59,7 +59,7 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
             Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : bool, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-        time_resolution_run_splitting : astropy.units.Quantity, optional
+        time_resolution : astropy.units.Quantity, optional
             Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         method : str, optional
             Decide if the acceptance is a direct event stacking or a fitted model. 'stack' or 'fit'
@@ -101,9 +101,9 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
                          cos_zenith_binning_parameter_value=cos_zenith_binning_parameter_value,
                          initial_cos_zenith_binning=initial_cos_zenith_binning,
                          max_angular_separation_wobble=max_angular_separation_wobble,
-                         max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
                          zenith_binning_run_splitting=zenith_binning_run_splitting,
-                         time_resolution_run_splitting=time_resolution_run_splitting)
+                         max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
+                         time_resolution=time_resolution)
 
     def fit_background(self, count_map, exp_map_total, exp_map):
         centers = self.offset_axis.center.to_value(u.deg)

--- a/acceptance_modelisation/radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/radial_acceptance_map_creator.py
@@ -22,7 +22,7 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
                  zenith_binning_run_splitting: bool = False,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_run_splitting: u.Quantity = 0.1 * u.s) -> None:
+                 time_resolution: u.Quantity = 0.1 * u.s) -> None:
         """
         Create the class for calculating radial acceptance model
         This class should be use when strict 2D model is good enough
@@ -50,7 +50,7 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
             Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-        time_resolution_run_splitting : astropy.units.Quantity, optional
+        time_resolution : astropy.units.Quantity, optional
             Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         """
 
@@ -65,7 +65,7 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
                          max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
                          max_angular_separation_wobble=max_angular_separation_wobble,
                          zenith_binning_run_splitting=zenith_binning_run_splitting,
-                         time_resolution_run_splitting=time_resolution_run_splitting)
+                         time_resolution=time_resolution)
 
     def _create_base_computation_map(self, observations: Observation) -> Tuple[WcsNDMap, WcsNDMap, WcsNDMap, u.Unit]:
         """

--- a/acceptance_modelisation/radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/radial_acceptance_map_creator.py
@@ -45,7 +45,7 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
-        zenith_binning_run_splitting : float, optional
+        zenith_binning_run_splitting : bool, optional
             If true, will split each run to match zenith binning for the base model computation
             Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional

--- a/acceptance_modelisation/radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/radial_acceptance_map_creator.py
@@ -45,8 +45,9 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
-        zenith_binning_run_splitting : flaot, optional
-            If true, will split each run to match zenith binning for the base model computation, no effect on the interpolation phase itself, could be compute expensive
+        zenith_binning_run_splitting : float, optional
+            If true, will split each run to match zenith binning for the base model computation
+            Could be computationally expensive, especially at high zenith with a high resolution zenith binning
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
         time_resolution_run_splitting : astropy.units.Quantity, optional

--- a/acceptance_modelisation/radial_acceptance_map_creator.py
+++ b/acceptance_modelisation/radial_acceptance_map_creator.py
@@ -20,8 +20,9 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
                  cos_zenith_binning_parameter_value: int = 3600,
                  initial_cos_zenith_binning: float = 0.01,
                  max_angular_separation_wobble: u.Quantity = 0.4 * u.deg,
+                 zenith_binning_run_splitting: bool = False,
                  max_fraction_pixel_rotation_fov: float = 0.5,
-                 time_resolution_rotation_fov: u.Quantity = 0.1 * u.s) -> None:
+                 time_resolution_run_splitting: u.Quantity = 0.1 * u.s) -> None:
         """
         Create the class for calculating radial acceptance model
         This class should be use when strict 2D model is good enough
@@ -44,10 +45,12 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
             Initial bin size for cos zenith binning
         max_angular_separation_wobble : u.Quantity, optional
             The maximum angular separation between identified wobbles, in degrees
+        zenith_binning_run_splitting : flaot, optional
+            If true, will split each run to match zenith binning for the base model computation, no effect on the interpolation phase itself, could be compute expensive
         max_fraction_pixel_rotation_fov : float, optional
             For camera frame transformation the maximum size relative to a pixel a rotation is allowed
-        time_resolution_rotation_fov : astropy.unit.Quantity, optional
-            Time resolution to use for the computation of the rotation of the FoV
+        time_resolution_run_splitting : astropy.units.Quantity, optional
+            Time resolution to use for the computation of the rotation of the FoV and cut as function of the zenith bins
         """
 
         # Initiate upper instance
@@ -60,7 +63,8 @@ class RadialAcceptanceMapCreator(BaseRadialAcceptanceMapCreator):
                          initial_cos_zenith_binning=initial_cos_zenith_binning,
                          max_fraction_pixel_rotation_fov=max_fraction_pixel_rotation_fov,
                          max_angular_separation_wobble=max_angular_separation_wobble,
-                         time_resolution_rotation_fov=time_resolution_rotation_fov)
+                         zenith_binning_run_splitting=zenith_binning_run_splitting,
+                         time_resolution_run_splitting=time_resolution_run_splitting)
 
     def _create_base_computation_map(self, observations: Observation) -> Tuple[WcsNDMap, WcsNDMap, WcsNDMap, u.Unit]:
         """


### PR DESCRIPTION
A new option called zenith_binning_run_splitting allow to activate a mode that split the runs as function of the binning before merging bins and computing the model for each bin. 

The modification is not affecting the interpolation or binning associated done after model computation.