### PR TITLE
Add support for computing the acceptance model from off runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 dist
 __pycache__
 .idea
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ There are at this stage no define file format for storing the intermediate resul
 
 ### Creating the model
 
-The example below create the object containing the zenith binned model.
-The ``obs_collection` provided could either be your ON runs if you want to compute background directly from the data or OFF runs if you want to use other data for the background model.
+The example below create the `BackgroundCollectionZenith` object containing the zenith binned model.
+The `obs_collection` provided could either be your ON runs if you want to compute background directly from the data or OFF runs if you want to use other data for the background model.
 
 ```python
 acceptance_model_creator = RadialAcceptanceMapCreator(energy_axis_acceptance,
@@ -194,14 +194,14 @@ base_model = acceptance_model_creator.create_model_cos_zenith_binned(obs_collect
 
 ### Storing and loading a model with pickle
 
-The object containing the models could then be store using pickle.
+The `BackgroundCollectionZenith` object containing the models could then be store using pickle.
 ```python
 import pickle
 with open('my_bkg_model.pck', mode='wb') as f:
     pickle.dump(base_model, f)
 ```
 
-It is then possible to retrieve it later using pickle again.
+It is then possible to retrieve it later using pickle.
 ```python
 import pickle
 with open('my_bkg_model.pck', mode='rb') as f:
@@ -210,7 +210,7 @@ with open('my_bkg_model.pck', mode='rb') as f:
 
 ### Applying a model in memory
 
-When you have a precomputed model in memory, it is possible to apply it directly on a give set of runs.
+When you have a precomputed model in memory, it is possible to apply it directly on a give set of runs by using the `base_mode` parameter.
 ```python
 acceptance_model_creator = RadialAcceptanceMapCreator(energy_axis_acceptance,
                                                       offset_axis_acceptance,

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ It could be in some case useful to precompute a model and applying it on data la
 
 However, it's possible to use this functionality without OFF runs or zenith interpolation. In the last case you just need to provide a model in a gammapy format.
 
-There are at this stage no define file format for storing the intermediate results, we suggest to store the dictionary created directly using pickle.
+There are at this stage no define file format for storing the intermediate results, we suggest to store the BackgroundCollectionZenith object created directly using pickle.
 
 ### Creating and storing the model
 ```python

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ acceptance_models = acceptance_model_creator.create_acceptance_map_per_observati
                                                                                    zenith_interpolation=True)
 ```
 
-## Using off runs for background model
+## Using OFF runs for background model
 
-It's also possible to create a model from OFF runs and to apply in on runs you want to analyse. The exclusions regions should cover potential sources both in the on and off runs. The OFF runs doesn't need to be connected.
+It is also possible to create a model from OFF runs and to apply in ON runs you want to analyse. The exclusions regions should cover potential sources both in the ON and OFF runs at the same time. The OFF runs doesn't need to be spatially connected.
 ```python
 acceptance_model_creator = RadialAcceptanceMapCreator(energy_axis_acceptance,
                                                       offset_axis_acceptance,
@@ -171,7 +171,11 @@ acceptance_models = acceptance_model_creator.create_acceptance_map_per_observati
 
 ## Store background model for later application
 
-It could be in some case usefull to precompute a model and applying it on data later. The example below cover the case where you want to use a model per run using zenith interpolation and off runs. But it's possible to use this functionality without off runs or zenith interpolation. In the last case you just need to provide a model in a gammapy format.
+It could be in some case usefull to precompute a model and applying it on data later. The example below cover the case where you want to use a model per run using zenith interpolation and OFF runs.
+
+However, it's possible to use this functionality without OFF runs or zenith interpolation. In the last case you just need to provide a model in a gammapy format.
+
+There are at this stage no define file format for storing the intermediate results, we suggest to store the dictionary created directly using pickle.
 
 ### Creating and storing the model
 ```python

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ acceptance_models = acceptance_model_creator.create_acceptance_map_per_observati
 
 ## Store background model for later application
 
-It could be in some case usefull to precompute a model and applying it on data later. The example below cover the case where you want to use a model per run using zenith interpolation and OFF runs.
+It could be in some case useful to precompute a model and applying it on data later. The example below cover the case where you want to use a model per run using zenith interpolation and OFF runs.
 
 However, it's possible to use this functionality without OFF runs or zenith interpolation. In the last case you just need to provide a model in a gammapy format.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ acceptance_models = acceptance_model_creator.create_acceptance_map_per_observati
 
 ## Store background model for later application
 
-It could be in some case useful to precompute a model and applying it on data later. The example below cover the case where you want to use a model per run using zenith interpolation and OFF runs.
+It could be in some case useful to precompute a model and to apply it on data later. The example below cover the case where you want to use a model per run using zenith interpolation and OFF runs.
 
 However, it's possible to use this functionality without OFF runs or zenith interpolation. In the last case you just need to provide a model in a gammapy format.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ acceptance_models = acceptance_model_creator.create_acceptance_map_per_observati
 
 ## Using OFF runs for background model
 
-It is also possible to create a model from OFF runs and to apply in ON runs you want to analyse. The exclusions regions should cover potential sources both in the ON and OFF runs at the same time. The OFF runs doesn't need to be spatially connected.
+It is also possible to create a model from OFF runs and to apply in ON runs you want to analyse. The exclusions regions should cover potential sources both in the ON and OFF runs at the same time. The OFF runs don't need to be spatially connected.
 ```python
 acceptance_model_creator = RadialAcceptanceMapCreator(energy_axis_acceptance,
                                                       offset_axis_acceptance,
@@ -177,27 +177,41 @@ However, it's possible to use this functionality without OFF runs or zenith inte
 
 There are at this stage no define file format for storing the intermediate results, we suggest to store the BackgroundCollectionZenith object created directly using pickle.
 
-### Creating and storing the model
+### Creating the model
+
+The example below create the object containing the zenith binned model.
+The ``obs_collection` provided could either be your ON runs if you want to compute background directly from the data or OFF runs if you want to use other data for the background model.
+
 ```python
-import pickle
 acceptance_model_creator = RadialAcceptanceMapCreator(energy_axis_acceptance,
                                                       offset_axis_acceptance,
                                                       exclude_regions=exclude_regions,
                                                       oversample_map=10,
                                                       min_run_per_cos_zenith_bin=3,
                                                       initial_cos_zenith_binning=0.01)
-base_model = acceptance_model_creator.create_model_cos_zenith_binned(obs_collection_off)
+base_model = acceptance_model_creator.create_model_cos_zenith_binned(obs_collection)
+```
 
+### Storing and loading a model with pickle
+
+The object containing the models could then be store using pickle.
+```python
+import pickle
 with open('my_bkg_model.pck', mode='wb') as f:
     pickle.dump(base_model, f)
 ```
 
-### Loading and applying the model
+It is then possible to retrieve it later using pickle again.
 ```python
 import pickle
 with open('my_bkg_model.pck', mode='rb') as f:
     base_model = pickle.load(f)
-    
+```
+
+### Applying a model in memory
+
+When you have a precomputed model in memory, it is possible to apply it directly on a give set of runs.
+```python
 acceptance_model_creator = RadialAcceptanceMapCreator(energy_axis_acceptance,
                                                       offset_axis_acceptance,
                                                       exclude_regions=exclude_regions)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ There are at this stage no define file format for storing the intermediate resul
 
 ### Creating the model
 
-The example below create the `BackgroundCollectionZenith` object containing the zenith binned model.
+The example below creates the `BackgroundCollectionZenith` object containing the zenith binned model.
 The `obs_collection` provided could either be your ON runs if you want to compute background directly from the data or OFF runs if you want to use other data for the background model.
 
 ```python
@@ -210,7 +210,7 @@ with open('my_bkg_model.pck', mode='rb') as f:
 
 ### Applying a model in memory
 
-When you have a precomputed model in memory, it is possible to apply it directly on a give set of runs by using the `base_mode` parameter.
+When you have a precomputed model in memory, it is possible to apply it directly on a given set of runs by using the `base_mode` parameter.
 ```python
 acceptance_model_creator = RadialAcceptanceMapCreator(energy_axis_acceptance,
                                                       offset_axis_acceptance,

--- a/acceptance_modelisation/__init__.py
+++ b/acceptance_modelisation/__init__.py
@@ -2,3 +2,4 @@ from .base_radial_acceptance_map_creator import BaseRadialAcceptanceMapCreator
 from .base_acceptance_map_creator import BaseAcceptanceMapCreator
 from .grid3d_acceptance_map_creator import Grid3DAcceptanceMapCreator
 from .radial_acceptance_map_creator import RadialAcceptanceMapCreator
+from .bkg_collection import BackgroundCollectionZenith

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -623,7 +623,7 @@ class BaseAcceptanceMapCreator(ABC):
         Parameters
         ----------
         observations : gammapy.data.observations.Observations
-            The collection of observations for which will be targeted the acceptance map
+            The collection of observations to which the acceptance model will be applied
         off_observations : gammapy.data.observations.Observations
             The collection of observations used to generate the acceptance map, if None will be the observations provided as target
         base_model : dict of gammapy.irf.background.BackgroundIRF
@@ -673,7 +673,7 @@ class BaseAcceptanceMapCreator(ABC):
         Parameters
         ----------
         observations : gammapy.data.observations.Observations
-            The collection of observations for which will be targeted the acceptance map
+            The collection of observations to which the acceptance model will be applied
         off_observations : gammapy.data.observations.Observations
             The collection of observations used to generate the acceptance map, if None will be the observations provided as target
         base_model : dict of gammapy.irf.background.BackgroundIRF
@@ -745,7 +745,7 @@ class BaseAcceptanceMapCreator(ABC):
         Parameters
         ----------
         observations : gammapy.data.observations.Observations
-            The collection of observations for which will be targeted the acceptance map
+            The collection of observations to which the acceptance model will be applied
         zenith_binning : bool, optional
             If true the acceptance maps will be generated using zenith binning
         zenith_interpolation : bool, optional

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -353,8 +353,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         return count_map_background, exp_map_background, exp_map_background_total, livetime
 
-    @staticmethod
-    def _check_base_model(base_model, only_raw_model: bool = False, only_zenith_model: bool = False):
+    def _check_base_model(self, base_model, only_raw_model: bool = False, only_zenith_model: bool = False):
         """
         Method to verify format of a base model provided for computation
 

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -378,34 +378,34 @@ class BaseAcceptanceMapCreator(ABC):
             if isinstance(base_model, BackgroundIRF):
                 if only_zenith_model:
                     error_message = 'Invalid base model format, please provide a dict of BackgroundIRF'
-                    logging.error(error_message)
+                    logger.error(error_message)
                     raise BackgroundModelFormatException(error_message)
             elif isinstance(base_model, dict):
                 if only_raw_model:
                     error_message = 'Invalid base model format, please provide a BackgroundIRF'
-                    logging.error(error_message)
+                    logger.error(error_message)
                     raise BackgroundModelFormatException(error_message)
                 for k in base_model.keys():
                     if not isinstance(k, (np.floating, float)):
                         error_message = 'Invalid type for keys in the dictionary, should be float value, ' + str(
                             type(k)) + ' provided'
-                        logging.error(error_message)
+                        logger.error(error_message)
                         raise BackgroundModelFormatException(error_message)
                     elif k > 90.0 or k < 0.0:
                         error_message = ('Invalid value for keys in the dictionary, the should represent the zenith of '
                                          'the model in degree with a value between 0 and 90, ') + str(
                             k) + ' provided'
-                        logging.error(error_message)
+                        logger.error(error_message)
                         raise BackgroundModelFormatException(error_message)
                     if not isinstance(base_model[k], BackgroundIRF):
                         error_message = 'Invalid base model format, each entry should be a BackgroundIRF, ' + str(
                             type(base_model[k])) + ' provided'
-                        logging.error(error_message)
+                        logger.error(error_message)
                         raise BackgroundModelFormatException(error_message)
             else:
                 error_message = ('Invalid base model format, please provide either a BackgroundIRF or a dict of '
                                  'BackgroundIRF, ') + str(type(base_model)) + ' provided'
-                logging.error(error_message)
+                logger.error(error_message)
                 raise BackgroundModelFormatException(error_message)
 
     @abstractmethod

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -410,9 +410,9 @@ class BaseAcceptanceMapCreator(ABC):
 
         return normalised_acceptance_map
 
-    def _create_model_cos_zenith_binned(self,
-                                        observations: Observations
-                                        ) -> dict[Any, BackgroundIRF]:
+    def create_model_cos_zenith_binned(self,
+                                       observations: Observations
+                                       ) -> dict[Any, BackgroundIRF]:
         """
         Calculate a model for each cos zenith bin
 

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -574,6 +574,7 @@ class BaseAcceptanceMapCreator(ABC):
             The collection of observations to which the acceptance model will be applied
         off_observations : gammapy.data.observations.Observations
             The collection of observations used to generate the acceptance map, if None will be the observations provided as target
+            Will be ignored if a base_model parameter is provided
         base_model : BackgroundCollectionZenith
             If you have already a precomputed model, the method will use this model as base for the acceptance map instead of computing it from the data
 
@@ -586,6 +587,8 @@ class BaseAcceptanceMapCreator(ABC):
 
         if off_observations is None:
             off_observations = observations
+        elif base_model is not None:
+            logger.warning('The off observations provided will be ignored as a base model has been provided.')
 
         # If needed produce the zenith binned model
         dict_binned_model = base_model or self.create_model_cos_zenith_binned(off_observations)
@@ -622,6 +625,7 @@ class BaseAcceptanceMapCreator(ABC):
             The collection of observations to which the acceptance model will be applied
         off_observations : gammapy.data.observations.Observations
             The collection of observations used to generate the acceptance map, if None will be the observations provided as target
+            Will be ignored if a base_model parameter is provideds
         base_model : BackgroundCollectionZenith
             If you have already a precomputed model, the method will use this model as base for the acceptance map instead of computing it from the data
 
@@ -634,6 +638,8 @@ class BaseAcceptanceMapCreator(ABC):
 
         if off_observations is None:
             off_observations = observations
+        elif base_model is not None:
+            logger.warning('The off observations provided will be ignored as a base model has been provided.')
 
         # If needed produce the zenith binned model
         dict_binned_model = base_model or self.create_model_cos_zenith_binned(off_observations)

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -710,6 +710,8 @@ class BaseAcceptanceMapCreator(ABC):
 
         if off_observations is None:
             off_observations = observations
+        elif base_model is not None:
+            logger.warning('The off observations provided will be ignored as a base model has been provided.')
 
         acceptance_map = {}
         if zenith_interpolation:

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -764,8 +764,6 @@ class BaseAcceptanceMapCreator(ABC):
             A dict with observation number as key and a background model that could be used as an acceptance model associated at each key
         """
 
-        self._check_base_model(base_model)
-
         if off_observations is None:
             off_observations = observations
 

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -642,12 +642,9 @@ class BaseAcceptanceMapCreator(ABC):
         if off_observations is None:
             off_observations = observations
 
-        if base_model is None:
-            # Produce the binned model
-            dict_binned_model = self.create_model_cos_zenith_binned(off_observations)
-        else:
-            # Use the preexisting model
-            dict_binned_model = base_model
+        # If needed produce the zenith binned model
+        dict_binned_model = base_model or self.create_model_cos_zenith_binned(off_observations)
+
         cos_zenith_model = []
         key_model = []
         for k in np.sort(list(dict_binned_model.keys())):

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -635,12 +635,9 @@ class BaseAcceptanceMapCreator(ABC):
         if off_observations is None:
             off_observations = observations
 
-        if base_model is None:
-            # Produce the binned model
-            dict_binned_model = self.create_model_cos_zenith_binned(off_observations)
-        else:
-            # Use the preexisting model
-            dict_binned_model = base_model
+        # If needed produce the zenith binned model
+        dict_binned_model = base_model or self.create_model_cos_zenith_binned(off_observations)
+
         binned_model = []
         cos_zenith_model = []
         for k in np.sort(list(dict_binned_model.keys())):

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -591,6 +591,10 @@ class BaseAcceptanceMapCreator(ABC):
             logger.warning('The off observations provided will be ignored as a base model has been provided.')
 
         # If needed produce the zenith binned model
+        if base_model is not None and not isinstance(base_model, BackgroundCollectionZenith):
+            error_message = 'The models should be provided as a BackgroundCollectionZenith object'
+            logger.error(error_message)
+            raise BackgroundModelFormatException(error_message)
         dict_binned_model = base_model or self.create_model_cos_zenith_binned(off_observations)
 
         cos_zenith_model = []
@@ -642,6 +646,10 @@ class BaseAcceptanceMapCreator(ABC):
             logger.warning('The off observations provided will be ignored as a base model has been provided.')
 
         # If needed produce the zenith binned model
+        if base_model is not None and not isinstance(base_model, BackgroundCollectionZenith):
+            error_message = 'The models should be provided as a BackgroundCollectionZenith object'
+            logger.error(error_message)
+            raise BackgroundModelFormatException(error_message)
         dict_binned_model = base_model or self.create_model_cos_zenith_binned(off_observations)
 
         binned_model = []
@@ -728,6 +736,10 @@ class BaseAcceptanceMapCreator(ABC):
                                                                           base_model=base_model)
         else:
             if base_model is not None:
+                if not isinstance(base_model, BackgroundIRF):
+                    error_message = 'The model provided should be a gammapy BackgroundIRF object'
+                    logger.error(error_message)
+                    raise BackgroundModelFormatException(error_message)
                 unique_base_acceptance_map = base_model
             else:
                 unique_base_acceptance_map = self.create_acceptance_map(off_observations)

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -774,11 +774,6 @@ class BaseAcceptanceMapCreator(ABC):
             A dict with observation number as key and a background model that could be used as an acceptance model associated at each key
         """
 
-        if off_observations is None:
-            off_observations = observations
-        elif base_model is not None:
-            logger.warning('The off observations provided will be ignored as a base model has been provided.')
-
         acceptance_map = {}
         if zenith_interpolation:
             acceptance_map = self.create_acceptance_map_cos_zenith_interpolated(observations=observations,
@@ -789,6 +784,11 @@ class BaseAcceptanceMapCreator(ABC):
                                                                           off_observations=off_observations,
                                                                           base_model=base_model)
         else:
+            if off_observations is None:
+                off_observations = observations
+            elif base_model is not None:
+                logger.warning('The off observations provided will be ignored as a base model has been provided.')
+
             if base_model is not None:
                 if not isinstance(base_model, BackgroundIRF):
                     error_message = 'The model provided should be a gammapy BackgroundIRF object'

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -476,7 +476,8 @@ class BaseAcceptanceMapCreator(ABC):
         return dict_binned_model
 
     def create_acceptance_map_cos_zenith_binned(self,
-                                                observations: Observations
+                                                observations: Observations,
+                                                off_observations: Observations = None
                                                 ) -> dict[Any, BackgroundIRF]:
         """
         Calculate an acceptance map per run using cos zenith binning
@@ -484,7 +485,9 @@ class BaseAcceptanceMapCreator(ABC):
         Parameters
         ----------
         observations : gammapy.data.observations.Observations
-            The collection of observations used to make the acceptance map
+            The collection of observations for which will be targeted the acceptance map
+        off_observations : gammapy.data.observations.Observations
+            The collection of observations used to generate the acceptance map, if None will be the observations provided as target
 
         Returns
         -------
@@ -493,8 +496,11 @@ class BaseAcceptanceMapCreator(ABC):
 
         """
 
+        if off_observations is None:
+            off_observations = observations
+
         # Produce the binned model
-        dict_binned_model = self._create_model_cos_zenith_binned(observations)
+        dict_binned_model = self.create_model_cos_zenith_binned(off_observations)
         cos_zenith_model = []
         key_model = []
         for k in np.sort(list(dict_binned_model.keys())):
@@ -513,7 +519,8 @@ class BaseAcceptanceMapCreator(ABC):
         return acceptance_map
 
     def create_acceptance_map_cos_zenith_interpolated(self,
-                                                      observations: Observations
+                                                      observations: Observations,
+                                                      off_observations: Observations = None
                                                       ) -> dict[Any, BackgroundIRF]:
         """
         Calculate an acceptance map per run using cos zenith binning and interpolation
@@ -521,7 +528,9 @@ class BaseAcceptanceMapCreator(ABC):
         Parameters
         ----------
         observations : gammapy.data.observations.Observations
-            The collection of observations used to make the acceptance map
+            The collection of observations for which will be targeted the acceptance map
+        off_observations : gammapy.data.observations.Observations
+            The collection of observations used to generate the acceptance map, if None will be the observations provided as target
 
         Returns
         -------
@@ -530,8 +539,11 @@ class BaseAcceptanceMapCreator(ABC):
 
         """
 
+        if off_observations is None:
+            off_observations = observations
+
         # Produce the binned model
-        dict_binned_model = self._create_model_cos_zenith_binned(observations)
+        dict_binned_model = self.create_model_cos_zenith_binned(off_observations)
         binned_model = []
         cos_zenith_model = []
         for k in np.sort(list(dict_binned_model.keys())):
@@ -570,6 +582,7 @@ class BaseAcceptanceMapCreator(ABC):
                                               zenith_binning: bool = False,
                                               zenith_interpolation: bool = False,
                                               runwise_normalisation: bool = True,
+                                              off_observations: Observations = None,
                                               ) -> dict[Any, BackgroundIRF]:
         """
         Calculate an acceptance map with the norm adjusted for each run
@@ -577,13 +590,15 @@ class BaseAcceptanceMapCreator(ABC):
         Parameters
         ----------
         observations : gammapy.data.observations.Observations
-            The collection of observations used to make the acceptance map
+            The collection of observations for which will be targeted the acceptance map
         zenith_binning : bool, optional
             If true the acceptance maps will be generated using zenith binning
         zenith_interpolation : bool, optional
             If true the acceptance maps will be generated using zenith binning and interpolation
         runwise_normalisation : bool, optional
             If true the acceptance maps will be normalised runwise to the observations
+        off_observations : gammapy.data.observations.Observations
+            The collection of observations used to generate the acceptance map, if None will be the observations provided as target
 
         Returns
         -------
@@ -591,13 +606,16 @@ class BaseAcceptanceMapCreator(ABC):
             A dict with observation number as key and a background model that could be used as an acceptance model associated at each key
         """
 
+        if off_observations is None:
+            off_observations = observations
+
         acceptance_map = {}
         if zenith_interpolation:
             acceptance_map = self.create_acceptance_map_cos_zenith_interpolated(observations)
         elif zenith_binning:
             acceptance_map = self.create_acceptance_map_cos_zenith_binned(observations)
         else:
-            unique_base_acceptance_map = self.create_acceptance_map(observations)
+            unique_base_acceptance_map = self.create_acceptance_map(off_observations)
             for obs in observations:
                 acceptance_map[obs.obs_id] = unique_base_acceptance_map
 

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -698,6 +698,7 @@ class BaseAcceptanceMapCreator(ABC):
             If true the acceptance maps will be normalised runwise to the observations
         off_observations : gammapy.data.observations.Observations
             The collection of observations used to generate the acceptance map, if None will be the observations provided as target
+            Will be ignored if a base_model parameter is provided
         base_model : gammapy.irf.background.BackgroundIRF or BackgroundCollectionZenith
             If you have already a precomputed model, the method will use this model as base for the acceptance map instead of computing it from the data
             In the case of a zenith dependant model, you should provide a BackgroundCollectionZenith object

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -24,7 +24,6 @@ from .toolbox import compute_rotation_speed_fov, get_unique_wobble_pointings
 logger = logging.getLogger(__name__)
 
 
-
 class BaseAcceptanceMapCreator(ABC):
 
     def __init__(self,
@@ -355,7 +354,7 @@ class BaseAcceptanceMapCreator(ABC):
         return count_map_background, exp_map_background, exp_map_background_total, livetime
 
     @staticmethod
-    def _check_base_mode(base_model, only_raw_model: bool = False, only_zenith_model: bool = False):
+    def _check_base_model(base_model, only_raw_model: bool = False, only_zenith_model: bool = False):
         """
         Method to verify format of a base model provided for computation
 
@@ -504,7 +503,7 @@ class BaseAcceptanceMapCreator(ABC):
             i_method = methods[self.cos_zenith_binning_method]
         except KeyError:
             logger.error(f" KeyError : {self.cos_zenith_binning_method} not a valid zenith binning method.\nValid "
-                          f"methods are {[*methods]}")
+                         f"methods are {[*methods]}")
             raise
         per_wobble = i_method < 0
 
@@ -617,7 +616,7 @@ class BaseAcceptanceMapCreator(ABC):
     def create_acceptance_map_cos_zenith_binned(self,
                                                 observations: Observations,
                                                 off_observations: Observations = None,
-                                                base_model: dict = None
+                                                base_model: dict[Any, BackgroundIRF] = None
                                                 ) -> dict[Any, BackgroundIRF]:
         """
         Calculate an acceptance map per run using cos zenith binning
@@ -639,7 +638,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         """
 
-        self._check_base_mode(base_model, only_zenith_model=True)
+        self._check_base_model(base_model, only_zenith_model=True)
 
         if off_observations is None:
             off_observations = observations
@@ -670,7 +669,7 @@ class BaseAcceptanceMapCreator(ABC):
     def create_acceptance_map_cos_zenith_interpolated(self,
                                                       observations: Observations,
                                                       off_observations: Observations = None,
-                                                      base_model: dict = None
+                                                      base_model: dict[Any, BackgroundIRF] = None
                                                       ) -> dict[Any, BackgroundIRF]:
         """
         Calculate an acceptance map per run using cos zenith binning and interpolation
@@ -692,7 +691,7 @@ class BaseAcceptanceMapCreator(ABC):
 
         """
 
-        self._check_base_mode(base_model, only_zenith_model=True)
+        self._check_base_model(base_model, only_zenith_model=True)
 
         if off_observations is None:
             off_observations = observations
@@ -769,7 +768,7 @@ class BaseAcceptanceMapCreator(ABC):
             A dict with observation number as key and a background model that could be used as an acceptance model associated at each key
         """
 
-        self._check_base_mode(base_model)
+        self._check_base_model(base_model)
 
         if off_observations is None:
             off_observations = observations
@@ -785,7 +784,7 @@ class BaseAcceptanceMapCreator(ABC):
                                                                           base_model=base_model)
         else:
             if base_model is not None:
-                self._check_base_mode(base_model, only_raw_model=True)
+                self._check_base_model(base_model, only_raw_model=True)
                 unique_base_acceptance_map = base_model
             else:
                 unique_base_acceptance_map = self.create_acceptance_map(off_observations)

--- a/acceptance_modelisation/bkg_collection.py
+++ b/acceptance_modelisation/bkg_collection.py
@@ -1,0 +1,86 @@
+import logging
+import numpy as np
+from gammapy.irf import BackgroundIRF
+from .exception import BackgroundModelFormatException
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundCollectionZenith:
+
+    def __init__(self, bkg_dict: dict[float, BackgroundIRF] = None):
+        """
+            Create the class for storing a collection of model for different zenith angle
+
+            Parameters
+            ----------
+            bkg_dict : dict of gammapy.irf.BackgroundIRF
+                The collection of model in a dictionary with as key the zenith angle (in degree) associated to the model
+        """
+        self.bkg_dict = {}
+        if not bkg_dict is None:
+            for k in bkg_dict.keys():
+                self[k] = bkg_dict[k]
+
+    @property
+    def zenith(self):
+        """
+            Return the zenith available
+
+            Returns
+            ----------
+            keys : np.array
+                The zenith angle available in degree
+        """
+        return np.sort(np.array(list(self.bkg_dict.keys())))
+
+
+    def keys(self):
+        """
+            Return the keys available
+
+            Returns
+            ----------
+            keys : dict_keys
+                The keys (zenith angle) to available
+        """
+        return self.bkg_dict.keys()
+
+    def __getitem__(self, key: float):
+        return self.bkg_dict[key]
+
+    def __setitem__(self, key: float, value: BackgroundIRF):
+        """
+            Assign a new pair of zenith and background model
+            Check the format is compatible
+
+            Parameters
+            ----------
+            key : float
+                The zenith angle in degree
+            value: gammapy.irf.BackgroundIRF
+                The model associated to the zenith angle provided
+        """
+        if not isinstance(key, (np.floating, float)):
+            error_message = 'Invalid type for keys in the dictionary, should be float value, ' + str(
+                type(key)) + ' provided'
+            logger.error(error_message)
+            raise BackgroundModelFormatException(error_message)
+        elif key > 90.0 or key < 0.0:
+            error_message = ('Invalid value for keys in the dictionary, the should represent the zenith of '
+                             'the model in degree with a value between 0 and 90, ') + str(key) + ' provided'
+            logger.error(error_message)
+            raise BackgroundModelFormatException(error_message)
+        elif not isinstance(value, BackgroundIRF):
+            error_message = 'Invalid model, please provide a BackgroundIRF'
+            logger.error(error_message)
+            raise BackgroundModelFormatException(error_message)
+        elif len(self.bkg_dict) > 0 and not type(value) is type(self.bkg_dict[self.bkg_dict.keys()[0]]):
+            error_message = 'All the model in the collection need to be of the same type, ' + str(type(value)) + ' provided instead of ' + str(type(self.bkg_dict[list(self.bkg_dict.keys())[0]]))
+            logger.error(error_message)
+            raise BackgroundModelFormatException(error_message)
+        else:
+            self.bkg_dict[key] = value
+
+    def __len__(self):
+        return len(self.bkg_dict)

--- a/acceptance_modelisation/bkg_collection.py
+++ b/acceptance_modelisation/bkg_collection.py
@@ -63,21 +63,17 @@ class BackgroundCollectionZenith:
         if not isinstance(key, (np.floating, float)):
             error_message = 'Invalid type for keys in the dictionary, should be float value, ' + str(
                 type(key)) + ' provided'
-            logger.error(error_message)
             raise BackgroundModelFormatException(error_message)
         elif key > 90.0 or key < 0.0:
             error_message = ('Invalid value for keys in the dictionary, the should represent the zenith of '
                              'the model in degree with a value between 0 and 90, ') + str(key) + ' provided'
-            logger.error(error_message)
             raise BackgroundModelFormatException(error_message)
         elif not isinstance(value, BackgroundIRF):
             error_message = 'Invalid model, please provide a BackgroundIRF'
-            logger.error(error_message)
             raise BackgroundModelFormatException(error_message)
         elif len(self.bkg_dict) > 0 and not type(value) is type(self.bkg_dict[list(self.bkg_dict.keys())[0]]):
             error_message = 'All the model in the collection need to be of the same type, ' + str(
                 type(value)) + ' provided instead of ' + str(type(self.bkg_dict[list(self.bkg_dict.keys())[0]]))
-            logger.error(error_message)
             raise BackgroundModelFormatException(error_message)
         else:
             self.bkg_dict[key] = value

--- a/acceptance_modelisation/bkg_collection.py
+++ b/acceptance_modelisation/bkg_collection.py
@@ -34,7 +34,6 @@ class BackgroundCollectionZenith:
         """
         return np.sort(np.array(list(self.bkg_dict.keys())))
 
-
     def keys(self):
         """
             Return the keys available
@@ -76,7 +75,8 @@ class BackgroundCollectionZenith:
             logger.error(error_message)
             raise BackgroundModelFormatException(error_message)
         elif len(self.bkg_dict) > 0 and not type(value) is type(self.bkg_dict[self.bkg_dict.keys()[0]]):
-            error_message = 'All the model in the collection need to be of the same type, ' + str(type(value)) + ' provided instead of ' + str(type(self.bkg_dict[list(self.bkg_dict.keys())[0]]))
+            error_message = 'All the model in the collection need to be of the same type, ' + str(
+                type(value)) + ' provided instead of ' + str(type(self.bkg_dict[list(self.bkg_dict.keys())[0]]))
             logger.error(error_message)
             raise BackgroundModelFormatException(error_message)
         else:

--- a/acceptance_modelisation/bkg_collection.py
+++ b/acceptance_modelisation/bkg_collection.py
@@ -74,7 +74,7 @@ class BackgroundCollectionZenith:
             error_message = 'Invalid model, please provide a BackgroundIRF'
             logger.error(error_message)
             raise BackgroundModelFormatException(error_message)
-        elif len(self.bkg_dict) > 0 and not type(value) is type(self.bkg_dict[self.bkg_dict.keys()[0]]):
+        elif len(self.bkg_dict) > 0 and not type(value) is type(self.bkg_dict[list(self.bkg_dict.keys())[0]]):
             error_message = 'All the model in the collection need to be of the same type, ' + str(
                 type(value)) + ' provided instead of ' + str(type(self.bkg_dict[list(self.bkg_dict.keys())[0]]))
             logger.error(error_message)

--- a/acceptance_modelisation/exception.py
+++ b/acceptance_modelisation/exception.py
@@ -1,0 +1,3 @@
+class BackgroundModelFormatException(Exception):
+    def __init__(self, *args):
+        super().__init__(*args)


### PR DESCRIPTION
Allow computing the acceptance model from off runs to apply it to on runs. The README contain explanation on how to store a pre-computed model for later application.