### PR TITLE
Initialise logging config. Fix string in some log messages.

### DIFF
--- a/acceptance_modelisation/__init__.py
+++ b/acceptance_modelisation/__init__.py
@@ -2,3 +2,6 @@ from .base_radial_acceptance_map_creator import BaseRadialAcceptanceMapCreator
 from .base_acceptance_map_creator import BaseAcceptanceMapCreator
 from .grid3d_acceptance_map_creator import Grid3DAcceptanceMapCreator
 from .radial_acceptance_map_creator import RadialAcceptanceMapCreator
+
+import logging
+logging.basicConfig()

--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -535,12 +535,11 @@ class BaseAcceptanceMapCreator(ABC):
             bin_center.append(np.sum([wcos.value for wcos in weighted_cos_zenith_bin_per_obs]) / np.sum(
                 [livet.value for livet in livetime_per_obs]))
 
-        logger.info("cos zenith bin edges: ", list(np.round(cos_zenith_bin, 2)))
-        logger.info("cos zenith bin centers: ", list(np.round(bin_center, 2)))
-        logger.info(f"observation per bin: ", list(np.histogram(cos_zenith_observations, bins=cos_zenith_bin)[0]))
-        logger.info(f"livetime per bin [s]: ", list(
-            np.histogram(cos_zenith_observations, bins=cos_zenith_bin, weights=livetime_observations)[0].astype(
-                int)))
+        logger.info(f"cos zenith bin edges: {list(np.round(cos_zenith_bin, 2))}")
+        logger.info(f"cos zenith bin centers: {list(np.round(bin_center, 2))}")
+        logger.info(f"observation per bin: {list(np.histogram(cos_zenith_observations, bins=cos_zenith_bin)[0])}")
+        logger.info(f"livetime per bin [s]: " +
+                     f"{list(np.histogram(cos_zenith_observations, bins=cos_zenith_bin, weights=livetime_observations)[0].astype(int))}")
         if per_wobble:
             wobble_observations_bool_arr = [(np.array(wobble_observations.tolist()) == wobble) for wobble in
                                             np.unique(np.array(wobble_observations))]


### PR DESCRIPTION
The lack of a call to BasicConfig meant that no messages were displayed. It was not an issue before I set up every logging usage to defined logger because any call to logging.log would also call BasicConfig. But this is not the case anymore.

Also fix a few messages for which I naively replaced `print`.