### PR TITLE
Optimisation of _compute_time_intervals_based_on_zenith_bin using interpolation on coordinate transformation

### DIFF
--- a/acceptance_modelisation/base_acceptance_map_creator.py
+++ b/acceptance_modelisation/base_acceptance_map_creator.py
@@ -509,10 +509,11 @@ class BaseAcceptanceMapCreator(ABC):
         time_axis = np.linspace(obs.tstart, obs.tstop, num=n_bin)
 
         # Compute the zenith for each evaluation time
-        altaz_coordinates = obs.get_pointing_altaz(time_axis)
-        zenith_values = altaz_coordinates.zen
-        if np.any(zenith_values < np.min(edge_zenith_bin)) or np.any(zenith_values > np.max(edge_zenith_bin)):
-            logger.error('Run with zenith value outside of the considered range for zenith binning')
+        with erfa_astrom.set(ErfaAstromInterpolator(1000 * u.s)):
+            altaz_coordinates = obs.get_pointing_altaz(time_axis)
+            zenith_values = altaz_coordinates.zen
+            if np.any(zenith_values < np.min(edge_zenith_bin)) or np.any(zenith_values > np.max(edge_zenith_bin)):
+                logger.error('Run with zenith value outside of the considered range for zenith binning')
 
         # Split the time interval to transition between zenith bin
         id_bin = np.digitize(zenith_values, edge_zenith_bin)


### PR DESCRIPTION
Activate the interpolation for coordinate transformation for significant speed up of the method _compute_time_intervals_based_on_zenith_bin. The parameters used are the same as in the method _create_base_computation_map.

The speed up is around a factor 10 for this function.