### PR TITLE
Alternative dynamic binning computation

### DIFF
--- a/baccmod/base_acceptance_map_creator.py
+++ b/baccmod/base_acceptance_map_creator.py
@@ -34,8 +34,7 @@ from .toolbox import (compute_rotation_speed_fov,
                       get_unique_wobble_pointings,
                       get_time_mini_irf,
                       generate_irf_from_mini_irf,
-                      compute_neighbour_condition_validation,
-                      combine_adjacent_ndarray)
+                      compute_neighbour_condition_validation)
 
 logger = logging.getLogger(__name__)
 

--- a/baccmod/base_acceptance_map_creator.py
+++ b/baccmod/base_acceptance_map_creator.py
@@ -508,6 +508,8 @@ class BaseAcceptanceMapCreator(ABC):
             the optimal energy axis
         """
 
+        # Relative numerical tolerance for the energy bin width limit
+        r_tol = 1 + 1e-7
 
         edges_energy_axis = base_energy_axis.edges
 
@@ -530,10 +532,10 @@ class BaseAcceptanceMapCreator(ABC):
             # Index for the mean count criteria
             j_counts = np.sum(rev_cumsumdata >= self.dynamic_energy_axis_target_statistics)-1
             # Index for the max bin width criteria
-            j_maxw = np.sum(log_edges[i] - log_edges[:i-1] >= self.dynamic_energy_axis_maximum_wideness_bin)
+            j_maxw = np.sum((log_edges[i] - log_edges[:i-1]) > self.dynamic_energy_axis_maximum_wideness_bin * r_tol)
             if j_counts < min_i and j_maxw < min_i:
                 # Handle the last bin before the lower zeros, adding its lower edge and eventually merging with the previous bin
-                if i!=i0 and log_edges[indexes_edges[-2]] - log_edges[min_i] < self.dynamic_energy_axis_maximum_wideness_bin:
+                if i!=i0 and log_edges[indexes_edges[-2]] - log_edges[min_i] <= self.dynamic_energy_axis_maximum_wideness_bin * r_tol:
                     indexes_edges.pop(-1)
                 indexes_edges.append(min_i)
                 i = min_i-1

--- a/baccmod/base_acceptance_map_creator.py
+++ b/baccmod/base_acceptance_map_creator.py
@@ -481,7 +481,8 @@ class BaseAcceptanceMapCreator(ABC):
         """
         pass
 
-    def _compute_dynamic_energy_axis(self, base_energy_axis: MapAxis, data_energy_distribution: np.ndarray, nb_spatial_bin: int) -> MapAxis:
+
+    def _compute_dynamic_energy_axis(self, base_energy_axis: MapAxis, data: np.ndarray, nb_spatial_bin: int) -> MapAxis:
         """
         Compute a new energy axis from the base one to better have a more uniform number of event in each bin
 
@@ -489,7 +490,7 @@ class BaseAcceptanceMapCreator(ABC):
         ----------
         base_energy_axis: gammapy.maps.MapAxis
             the base energy axis
-        data_energy_distribution : np.ndarray
+        data : np.ndarray
             the count distribution only binned in energy (using base_energy_axis binning)
         nb_spatial_bin : int
             the number of spatial bin covering the data_energy_distribution
@@ -500,46 +501,51 @@ class BaseAcceptanceMapCreator(ABC):
             the optimal energy axis
         """
 
-        edges_energy_axis = list(np.asarray(base_energy_axis.edges.to_value(u.TeV), dtype=np.float64))
-        log_edges_energy_axis = list(np.log10(np.asarray(base_energy_axis.edges.to_value(u.TeV), dtype=np.float64)))
-        data = data_energy_distribution.copy()
 
-        abs_eps_comparison = 1e-7
-        rel_eps_comparison = 1+1e-7
+        edges_energy_axis = base_energy_axis.edges
 
-        i = len(data) - 1
-        while i >= 0:
-            data_cumsum = np.cumsum(data)
+        cumsumdata =np.cumsum(data)/nb_spatial_bin
+        rev_cumsumdata = np.cumsum(data[::-1])[::-1]/nb_spatial_bin
+        # Evaluate the bins with only zeros at the start and end of the distribution
+        nzl=np.nonzero(cumsumdata==0)[0]
+        nzh=np.nonzero(rev_cumsumdata==0)[0]
 
-            # If all data in this bin and at lower energy are 0 we stop there
-            if data_cumsum[i] == 0:
-                break
-            if len(data) == 1:
-                logger.warning('Dynamic binning stoped early as all bin have bin merged in one bin')
-                break
+        log_edges=np.log10(edges_energy_axis.to_value(u.TeV))
 
-            # Test if we are above the target statistics for this bin
-            if data[i] < self.dynamic_energy_axis_target_statistics*nb_spatial_bin:
-                # If it's not the lowest bin and there are non-zero data below, we merged with the bin below
-                if i > 0 and data_cumsum[i-1] > 0 and (log_edges_energy_axis[i+1]-log_edges_energy_axis[i-1]) < (self.dynamic_energy_axis_maximum_wideness_bin*rel_eps_comparison+abs_eps_comparison):
-                    edges_energy_axis.pop(i)
-                    log_edges_energy_axis.pop(i)
-                    data = combine_adjacent_ndarray(data, i-1)
-                    i -= 1
-                # Otherwise we merge with the bin above if able
-                elif i < (len(data)-1) and (log_edges_energy_axis[i+2]-log_edges_energy_axis[i]) < (self.dynamic_energy_axis_maximum_wideness_bin*rel_eps_comparison+abs_eps_comparison):
-                    edges_energy_axis.pop(i+1)
-                    log_edges_energy_axis.pop(i+1)
-                    data = combine_adjacent_ndarray(data, i)
-                # If not able to reach target statistics, we raise a warning and continue
-                else:
-                    logger.warning('Dynamic energy binning is unable to reach target statistics due to bin maximum bin wideness')
-                    i -= 1
-            # If test pass we continue
+
+        min_i = len(nzl)
+        i0=len(edges_energy_axis)-len(nzh)-1
+        i=i0
+        indexes_edges=[len(edges_energy_axis)-1]
+
+        # Evaluate bin edges fulfilling the dynamic criteria
+        while i>min_i:
+            # Index for the mean count criteria
+            j_counts = np.sum(rev_cumsumdata >= self.dynamic_energy_axis_target_statistics)-1
+            # Index for the max bin width criteria
+            j_maxw = np.sum(log_edges[i] - log_edges[:i-1] >= self.dynamic_energy_axis_maximum_wideness_bin)
+            if j_counts<min_i and j_maxw<min_i:
+                # Handle the last bin before the lower zeros, adding its lower edge and eventually merging with the previous bin
+                if i!=i0 and log_edges[indexes_edges[-2]] - log_edges[len(nzl)] < self.dynamic_energy_axis_maximum_wideness_bin:
+                    indexes_edges.pop(-1)
+                indexes_edges.append(len(nzl))
+                i=min_i-1
             else:
-                i -= 1
+                # Pick the first fulfilled criteria
+                if j_counts >= j_maxw:
+                    j=j_counts
+                else:
+                    j=j_maxw
+                    logger.warning(
+                        'Dynamic energy binning is unable to reach target statistics due to bin maximum bin wideness')
+                indexes_edges.append(j)
+                rev_cumsumdata -= rev_cumsumdata[j]
+                i=j
+        # Add all empty bins
+        indexes_edges=np.sort(np.concatenate([nzh, indexes_edges, nzl], dtype=int))
+        return MapAxis.from_energy_edges(edges_energy_axis[np.array(indexes_edges, dtype=int)], name='energy')
 
-        return MapAxis.from_energy_edges(edges_energy_axis*u.TeV, name='energy')
+
 
     def _create_base_computation_map(self, observations: Observation) -> Tuple[np.ndarray, WcsNDMap, WcsNDMap, u.Quantity, MapAxis]:
         """

--- a/baccmod/grid3d_acceptance_map_creator.py
+++ b/baccmod/grid3d_acceptance_map_creator.py
@@ -44,6 +44,8 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
                  dynamic_energy_axis: bool = False,
                  dynamic_energy_axis_target_statistics: int = 500,
                  dynamic_energy_axis_maximum_wideness_bin: float = 0.5,
+                 dynamic_energy_axis_merge_zeros_low_energy: bool = False,
+                 dynamic_energy_axis_merge_zeros_high_energy: bool = False,
                  cos_zenith_binning_method: str = 'min_livetime',
                  cos_zenith_binning_parameter_value: int = 3600,
                  initial_cos_zenith_binning: float = 0.01,
@@ -82,6 +84,10 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
             the target statistics per spatial and energy bin, for spatial, it is computed based on an average and therefore doesn't guaranty is is meet in every bin
         dynamic_energy_axis_maximum_wideness_bin: float
             energy bin will not be merged if the resulting bin will be wider (in logorarithmic space) than this value
+        dynamic_energy_axis_merge_zeros_low_energy: bool
+            decides if empty energy bins at low energy are merged during the dynamic binning
+        dynamic_energy_axis_merge_zeros_high_energy: bool
+            decides if empty energy bins at high energy are merged during the dynamic binning
         cos_zenith_binning_method : str, optional
             The method used for cos zenith binning: 'min_livetime','min_n_observation'
         cos_zenith_binning_parameter_value : int, optional
@@ -146,6 +152,8 @@ class Grid3DAcceptanceMapCreator(BaseAcceptanceMapCreator):
                          dynamic_energy_axis=dynamic_energy_axis,
                          dynamic_energy_axis_target_statistics=dynamic_energy_axis_target_statistics,
                          dynamic_energy_axis_maximum_wideness_bin=dynamic_energy_axis_maximum_wideness_bin,
+                         dynamic_energy_axis_merge_zeros_low_energy=dynamic_energy_axis_merge_zeros_low_energy,
+                         dynamic_energy_axis_merge_zeros_high_energy=dynamic_energy_axis_merge_zeros_high_energy,
                          cos_zenith_binning_method=cos_zenith_binning_method,
                          cos_zenith_binning_parameter_value=cos_zenith_binning_parameter_value,
                          initial_cos_zenith_binning=initial_cos_zenith_binning,

--- a/baccmod/radial_acceptance_map_creator.py
+++ b/baccmod/radial_acceptance_map_creator.py
@@ -32,6 +32,8 @@ class RadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
                  dynamic_energy_axis: bool = False,
                  dynamic_energy_axis_target_statistics: int = 500,
                  dynamic_energy_axis_maximum_wideness_bin: float = 0.5,
+                 dynamic_energy_axis_merge_zeros_low_energy: bool = False,
+                 dynamic_energy_axis_merge_zeros_high_energy: bool = False,
                  cos_zenith_binning_method: str = 'min_livetime',
                  cos_zenith_binning_parameter_value: int = 3600,
                  initial_cos_zenith_binning: float = 0.01,
@@ -67,6 +69,10 @@ class RadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
             the target statistics per spatial and energy bin, for spatial, it is computed based on an average and therefore doesn't guaranty is is meet in every bin
         dynamic_energy_axis_maximum_wideness_bin: float
             energy bin will not be merged if the resulting bin will be wider (in logorarithmic space) than this value
+        dynamic_energy_axis_merge_zeros_low_energy: bool
+            decides if empty energy bins at low energy are merged during the dynamic binning
+        dynamic_energy_axis_merge_zeros_high_energy: bool
+            decides if empty energy bins at high energy are merged during the dynamic binning
         cos_zenith_binning_method : str, optional
             The method used for cos zenith binning: 'min_livetime','min_n_observation'
         cos_zenith_binning_parameter_value : int, optional
@@ -114,6 +120,8 @@ class RadialAcceptanceMapCreator(BaseAcceptanceMapCreator):
                          dynamic_energy_axis=dynamic_energy_axis,
                          dynamic_energy_axis_target_statistics=dynamic_energy_axis_target_statistics,
                          dynamic_energy_axis_maximum_wideness_bin=dynamic_energy_axis_maximum_wideness_bin,
+                         dynamic_energy_axis_merge_zeros_low_energy=dynamic_energy_axis_merge_zeros_low_energy,
+                         dynamic_energy_axis_merge_zeros_high_energy=dynamic_energy_axis_merge_zeros_high_energy,
                          cos_zenith_binning_method=cos_zenith_binning_method,
                          cos_zenith_binning_parameter_value=cos_zenith_binning_parameter_value,
                          initial_cos_zenith_binning=initial_cos_zenith_binning,

--- a/baccmod/toolbox.py
+++ b/baccmod/toolbox.py
@@ -200,18 +200,3 @@ def compute_neighbour_condition_validation(a, axis, relative_threshold):
     count_neighbour_condition_valid[slice_down] += neighbour_condition_down.astype(np.uint8)
 
     return count_neighbour_condition_valid
-
-def combine_adjacent_ndarray(arr: np.ndarray, idx: int) -> np.ndarray:
-    """
-    Return a new array where arr[idx] and arr[idx+1] are replaced by their sum.
-    """
-    if not (0 <= idx < arr.size-1):
-        raise IndexError("idx must be between 0 and len(arr)-2")
-    # sum the two adjacent entries
-    s = arr[idx] + arr[idx+1]
-    # build the new array
-    return np.concatenate((
-        arr[:idx],           # all elements before idx
-        [s],                 # the merged value
-        arr[idx+2:]          # all elements after idx+1
-    ))


### PR DESCRIPTION
Proposal for an update of the dynamic binning computation. It finds the next bin edge directly instead of iteration over each bins to remove edges 1 by 1. 

Returns identical values as the current implemetation (except for the 0 bins at high energy).
Faster by ~33% but computation times are negligible. 


If to be merged, combine_adjacent_ndarray should also be removed.